### PR TITLE
fixed sticky form alignement on mobile

### DIFF
--- a/src/components/StickyForm/StickyForm.js
+++ b/src/components/StickyForm/StickyForm.js
@@ -8,8 +8,8 @@ import "./StickyForm.css";
 const stickyFormVariant = {
   animate: {
     scale: 2.5,
-    x: "65vw",
-    y: "15vw",
+    x: "40vw",
+    y: "35vw",
     rotateX: 360,
   },
 };


### PR DESCRIPTION
adjusted the default alignment for the sticky form on mobile when you click "sticky task +"
