### PR TITLE
fixed sticky form alignment on edit screen

### DIFF
--- a/src/components/StickyForm/StickyForm.js
+++ b/src/components/StickyForm/StickyForm.js
@@ -7,11 +7,10 @@ import "./StickyForm.css";
 // framer motion function for the sticky form
 const stickyFormVariant = {
   animate: {
-    scale: 2.5,
-    x: 90,
-    y: 150,
-
     rotateX: 360,
+    scale: 1.4,
+    x: 175,
+    y: 100,
   },
 };
 
@@ -51,6 +50,7 @@ const StickyForm = (props) => {
           handleSubmit();
         }}
         variants={stickyFormVariant}
+        // animate={{ rotateX: 360, scale: 1.4, x: 195, y: 100 }}
         animate="animate"
         transition={{
           duration: 0.4,


### PR DESCRIPTION
Fixed an alignment issue with the sticky form on the edit screen. It was appearing off screen to the left. It should appear on screen now. 

You should also be able to drag the sticky form around when on the edit screen as well. 